### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: CC0-1.0
 
 name: Update CODEOWNERS
+permissions:
+  contents: write
 on:
   workflow_dispatch:
   pull_request:

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: CC0-1.0
 
+permissions:
+  contents: read
 on:
   push:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/simplified-coding/simplified-coding/security/code-scanning/4](https://github.com/simplified-coding/simplified-coding/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the workflow's purpose (updating the `CODEOWNERS` file), the `contents: write` permission is necessary to allow the workflow to commit changes to the repository. All other permissions will be omitted to minimize the risk of misuse.

The `permissions` block will be added immediately after the `name` field (line 5) to apply these permissions to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
